### PR TITLE
fix(auth): use crypto/subtle to avoid timing attack on hmac signature

### DIFF
--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -3,6 +3,7 @@ package scheduler
 import (
 	"crypto/hmac"
 	"crypto/sha256"
+	"crypto/subtle"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -112,8 +113,7 @@ func (api *API) scheduler(w http.ResponseWriter, r *http.Request) {
 		hash := hmac.New(sha256.New, []byte(api.apiSecret))
 		hash.Write(body)
 		expectedSignature := "sha256=" + hex.EncodeToString(hash.Sum(nil))
-
-		if signature != expectedSignature {
+		if subtle.ConstantTimeCompare([]byte(signature), []byte(expectedSignature)) != 1 {
 			http.Error(w, "Invalid X-Hub-Signature-256 header. Make sure the environment variable API_SECRET matches your GitHub webhook secret.", http.StatusUnauthorized)
 			return
 		}

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -1,0 +1,96 @@
+package scheduler
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestSchedulerAuth(t *testing.T) {
+
+	// we're only testing Auth here, so let's fake handleAction
+	type fakeAPI struct {
+		API
+		handleAction func(payload *WebHookPayload) error
+	}
+
+	testCases := map[string]struct{
+		githubSecret string
+		apiSecret string
+		body string
+		expectedResponseCode int
+		disableAuthEnv string
+	}{
+		"secrets match": {
+			githubSecret: "foobar",
+			apiSecret: "foobar",
+			body : `{"action":"foobar"}`,
+			expectedResponseCode: http.StatusOK,
+		},
+		"secrets do not match": {
+			githubSecret: "foobar",
+			apiSecret: "",
+			body : `{"action":"foobar"}`,
+			expectedResponseCode: http.StatusUnauthorized,
+		},
+		"empty body": {
+			githubSecret: "foobar",
+			apiSecret: "foobar",
+			body : ``,
+			expectedResponseCode: http.StatusBadRequest,
+		},
+		"auth is disabled": {
+			githubSecret: "",
+			apiSecret: "",
+			body : `{"action":"foobar"}`,
+			expectedResponseCode: http.StatusOK,
+			disableAuthEnv: "true",
+		},
+	}
+
+	handleAction := func(payload *WebHookPayload) error {
+		return nil
+	}
+
+	for name, tc := range testCases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			t.Setenv("DISABLE_AUTH", tc.disableAuthEnv)
+			api := API{
+				apiSecret: tc.apiSecret,
+			}
+			fake := fakeAPI{
+				API: api,
+				handleAction:  handleAction,
+			}
+			
+			mux := http.NewServeMux()
+			mux.HandleFunc("/", fake.scheduler)
+			srv := httptest.NewServer(mux)
+			body := []byte(tc.body)
+		
+			hash := hmac.New(sha256.New, []byte(tc.githubSecret))
+			hash.Write(body)
+			sig := "sha256=" + hex.EncodeToString(hash.Sum(nil))
+				
+			client := http.DefaultClient
+			req, _ := http.NewRequest(http.MethodPost, srv.URL, bytes.NewReader(body))
+			req.Header.Add("X-Hub-Signature-256",sig)
+			resp, err := client.Do(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if resp.StatusCode != tc.expectedResponseCode {
+				t.Fatalf("Got: %d, want: %d", resp.StatusCode, tc.expectedResponseCode)
+			}
+		})
+	}
+
+
+	
+	
+}


### PR DESCRIPTION
Use `subtle.ConstantTimeCompare` to compare hmac signature to avoid timing attack with new unit test.